### PR TITLE
Don't require outdated `wasm-bindgen` feature from `uuid`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ cfg-if = "1.0.0"
 delegate-display = "2"
 fancy_constructor = "1.2.2"
 js-sys = "0.3.64"
-uuid = {version = "1.5.0", features = ["v4", "wasm-bindgen", "js"]}
+uuid = {version = "1.5.0", features = ["v4", "js"]}
 wasm-bindgen = "0.2.87"
 wasm-bindgen-futures = "0.4.37"
 


### PR DESCRIPTION
The `uuid` package hasn't had the feature `wasm-bindgen` since https://github.com/uuid-rs/uuid/pull/536, in which it was renamed to `js`, but using it continues to work on `wasm32-unknown-unknown` because it accidentally activates the optional `wasm-bindgen` dependency that is only available on that platform.